### PR TITLE
Update PersistentProjectileEntityMixin to Remove STDOUT log

### DIFF
--- a/src/main/java/com/github/clevernucleus/playerex/mixin/PersistentProjectileEntityMixin.java
+++ b/src/main/java/com/github/clevernucleus/playerex/mixin/PersistentProjectileEntityMixin.java
@@ -56,7 +56,7 @@ abstract class PersistentProjectileEntityMixin extends ProjectileEntity {
 				damage = DataAttributesAPI.ifPresent(livingEntity, ExAPI.RANGED_CRIT_DAMAGE, fallback, value -> (float)(amount * (1.0 + (10.0 * value))));
 			}
 		}
-		System.out.println("DAMAGE: " + damage);
+		// System.out.println("DAMAGE: " + damage);
 		return damage;
 	}
 }


### PR DESCRIPTION
This debug log keep spamming my server logs and it sometimes gets a little too spammy

![image](https://github.com/CleverNucleus/playerex/assets/57152799/15490d36-7dd6-42e7-9ff4-bebf40e121c4)

(Using [BadStdOut](https://www.curseforge.com/minecraft/mc-mods/badstdout) to see what mod it was from)